### PR TITLE
Fixed placed blocks not being observed

### DIFF
--- a/src/main/java/hellfirepvp/observerlib/mixin/MixinLevelChunk.java
+++ b/src/main/java/hellfirepvp/observerlib/mixin/MixinLevelChunk.java
@@ -42,9 +42,6 @@ public abstract class MixinLevelChunk {
         if (this.prevState == null || this.level.isClientSide() || this.prevState == newState) {
             return;
         }
-        if (this.level.captureBlockSnapshots) {
-            return;
-        }
         LevelChunk thisLevelChunk = (LevelChunk)(Object) this;
         BlockChangeNotifier.onBlockChange(this.level, thisLevelChunk, pos, this.prevState, newState);
         this.prevState = null;


### PR DESCRIPTION
- Checking captureBlockSnapshots is unnecessary for listening to state changes and causes the change to not be visible when a block is placed. Snapshots should only be needed for forge events and will call a state change if used anyway