### PR TITLE
Avoid nullable registry

### DIFF
--- a/src/main/java/hellfirepvp/observerlib/common/registry/RegistryProviders.java
+++ b/src/main/java/hellfirepvp/observerlib/common/registry/RegistryProviders.java
@@ -21,10 +21,10 @@ import javax.annotation.Nullable;
 public class RegistryProviders {
 
     public static final ResourceKey<Registry<ObserverProvider>> REGISTRY_KEY = ResourceKey.createRegistryKey(ObserverLib.key("observer_providers"));
-    private static Registry<ObserverProvider> REGISTRY;
+    private static final Registry<ObserverProvider> REGISTRY = new RegistryBuilder<>(REGISTRY_KEY).create();
 
     public static void initialize(NewRegistryEvent event) {
-        REGISTRY = event.create(new RegistryBuilder<>(REGISTRY_KEY));
+        event.register(REGISTRY);
     }
 
     @Nullable

--- a/src/main/java/hellfirepvp/observerlib/common/registry/RegistryStructures.java
+++ b/src/main/java/hellfirepvp/observerlib/common/registry/RegistryStructures.java
@@ -21,10 +21,10 @@ import javax.annotation.Nullable;
 public class RegistryStructures {
 
     public static final ResourceKey<Registry<MatchableStructure>> REGISTRY_KEY = ResourceKey.createRegistryKey(ObserverLib.key("matchable_structures"));
-    private static Registry<MatchableStructure> REGISTRY;
+    private static final Registry<MatchableStructure> REGISTRY = new RegistryBuilder<>(REGISTRY_KEY).create();
 
     public static void initialize(NewRegistryEvent event) {
-        REGISTRY = event.create(new RegistryBuilder<>(REGISTRY_KEY));
+        event.register(REGISTRY);
     }
 
     @Nullable


### PR DESCRIPTION
Makes it so the custom modded registries can never be null at any point in time.